### PR TITLE
Fix for Windows Git, minor spelling/grammar.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+* text=auto eol=lf
+*.{cmd,[cC][mM][dD]} text eol=crlf
+*.{bat,[bB][aA][tT]} text eol=crlf

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .vscode
+.devcontainer
 vendor
 !vendor/composer

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-* Add latestl version of PHPStan to GrumPHP sniffs
+* Add latest version of PHPStan to GrumPHP sniffs
 
 ### Fix
 
-* Fix issue where page content is being stripped.
+* Fix issue where page content is being stripped
 
 ### Update
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 **TL;DR:** Removes all empty shortcodes from WordPress standard post types.
 
 If you've ever installed a plugin then used the plugin for an extended amount of time,
-then much of your contet likely includes that shortcode.
+then much of your content likely includes that shortcode.
 
 If you opt to disable that plugin and it doesn't properly clean up after itself, then much of your contennt is going to include shortcodes that don't mean anything to your readers.
 


### PR DESCRIPTION
- Add .gitattributes file to prevent Git from converting LF to CRLF when repo is pulled on Windows.
- Add .devcontainer (VSCode) to .gitignore.
- Minor spelling/grammar enhancements.